### PR TITLE
Changes to make scylla-cqlsh easily package inside scylla-java-tools

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -42,7 +42,7 @@ jobs:
 
   integration_test:
     name: Integration Tests
-    if: contains(github.event.pull_request.labels.*.name, 'test-build') || github.event_name == 'push' && endsWith(github.event.ref, 'scylla')
+    if: github.event_name == 'push' && endsWith(github.event.ref, 'scylla')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -47,7 +47,11 @@ if platform.python_implementation().startswith('Jython'):
 UTF8 = 'utf-8'
 
 description = "CQL Shell for Apache Cassandra"
-version = "6.2.0"
+
+try:
+    from cqlshlib._version import __version__ as version
+except ImportError:
+    version = "6.2.0"
 
 readline = None
 try:

--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -59,7 +59,7 @@ try:
 except ImportError:
     pass
 
-CQL_LIB_PREFIX = 'cassandra-driver-internal-only-'
+CQL_LIB_PREFIX = 'scylla-driver-'
 
 CASSANDRA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')
 CASSANDRA_CQL_HTML_FALLBACK = 'https://cassandra.apache.org/doc/latest/cql/index.html'
@@ -109,11 +109,10 @@ def find_zip(libprefix):
 
 cql_zip = find_zip(CQL_LIB_PREFIX)
 if cql_zip:
-    ver = os.path.splitext(os.path.basename(cql_zip))[0][len(CQL_LIB_PREFIX):]
-    sys.path.insert(0, os.path.join(cql_zip, 'cassandra-driver-' + ver))
+    sys.path.insert(0, cql_zip)
 
 # the driver needs dependencies
-third_parties = ('six-', 'pure_sasl-')
+third_parties = ('six-', 'pure_sasl-', 'PyYAML-')
 
 for lib in third_parties:
     lib_zip = find_zip(lib)

--- a/pylib/setup.py
+++ b/pylib/setup.py
@@ -15,19 +15,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import sys
-from distutils.core import setup
+import warnings
+from distutils.core import setup, Extension
 
 
 def get_extensions():
-    if "--no-compile" in sys.argv:
-        return []
+    if "--no-compile" not in sys.argv:
+        try:
+            from Cython.Build import cythonize
+            return cythonize(Extension(name='copyutil', sources=["cqlshlib/copyutil.py"], define_macros=[("CYTHON_LIMITED_API", "1")]))
+        except ImportError:
+            warnings.warn("installing cython could speed things up for you; `pip install cython`")
+    return []
 
-    from Cython.Build import cythonize
-    return cythonize("cqlshlib/copyutil.py")
 
 setup(
-    name="cassandra-pylib",
+    name="scylla-cqlsh",
     install_requires=[
         "scylla-driver",
         "six",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,11 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "Cython"
+    "Cython",
+    "setuptools_scm[toml]>=6.2"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "cqlshlib/_version.py"
+tag_regex = '^(?P<prefix>v)?(?P<version>[^\+-]+)(?P<suffix>-scylla)?$'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = cqlsh
-version = 6.0.1
 author = Israel Fruchter
 author_email = fruch@scylladb.com
 description = cqlsh is a Python-based command-line client for running CQL commands on a scylla cluster.


### PR DESCRIPTION
* change the prefixs for zip imports lookups
* make cython import optional - so source install can work without it
* name the package properly